### PR TITLE
feat: route /.well-known/jwks.json directly to barricade

### DIFF
--- a/deployments/barricade/base/auth-route.yaml
+++ b/deployments/barricade/base/auth-route.yaml
@@ -29,5 +29,13 @@ spec:
               type: ReplacePrefixMatch
 
     - backendRefs:
+        - name: barricade
+          port: 8080
+      matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+
+    - backendRefs:
         - name: auth-ui
           port: 80


### PR DESCRIPTION
Adds an exact path route for /.well-known/jwks.json to the barricade backend in the auth HTTPRoute.

## Changes
- Added new HTTPRoute rule to match exact path  and route it to 

## Verification
- Validated the updated auth-route.yaml syntax against the Gateway API HTTPRoute v1 spec.